### PR TITLE
Add first selectors (`selectEntity` and `selectEntities`)

### DIFF
--- a/.strangelogrc
+++ b/.strangelogrc
@@ -2,4 +2,5 @@ path: ./changelog
 components:
   actions: Actions
   reducer: Reducer
+  selectors: Selectors
   all: All

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **All:** Add [strangelog](https://github.com/neXenio/strangelog) to maintain a changelog
+- **Selectors:** Now exposing two selectors &#x60;selectEntity(schema: string, id: string)&#x60; and &#x60;selectEntities(schema: string, ids?: string[])&#x60;
 
 ### Changed
 _No entries_

--- a/changelog/next/2017-06-30T07:45:20.616Z_addition_selectors.yml
+++ b/changelog/next/2017-06-30T07:45:20.616Z_addition_selectors.yml
@@ -1,0 +1,6 @@
+dateTime: '2017-06-30T07:45:20.616Z'
+component: selectors
+kind: addition
+description: >-
+  Now exposing two selectors `selectEntity(schema: string, id: string)` and
+  `selectEntities(schema: string, ids?: string[])`

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,12 @@
 
 import createEntitiesReducer, { type StateType } from "./reducer";
 import { updateEntitiesAction, type UpdateEntitiesActionType } from "./actions";
+import { selectEntity, selectEntities } from "./selectors";
 
-export { createEntitiesReducer, updateEntitiesAction };
+export {
+  createEntitiesReducer,
+  updateEntitiesAction,
+  selectEntity,
+  selectEntities
+};
 export type { StateType, UpdateEntitiesActionType };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -9,10 +9,14 @@ export type SchemaMapType = {
   [schemaName: string]: Schema
 };
 
+export type EntityType = Object;
+
+export type SchemaEntitiesMapType = {
+  [id: string]: EntityType
+};
+
 export type StateType = {
-  [schema: string]: {
-    [id: string]: Object
-  }
+  [schema: string]: SchemaEntitiesMapType
 };
 
 function getInitialState(schemas: SchemaMapType): StateType {

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,0 +1,45 @@
+// @flow
+
+import {
+  type EntityType,
+  type StateType,
+  type SchemaEntitiesMapType
+} from "./reducer";
+
+export function selectEntity(
+  state: { entities: StateType },
+  schema: string,
+  id: string
+): ?EntityType {
+  const schemaEntities = selectSchemaEntitiesMap(state, schema);
+
+  return schemaEntities[id] || null;
+}
+
+export function selectEntities(
+  state: { entities: StateType },
+  schema: string,
+  ids?: string[]
+): EntityType[] {
+  const schemaEntities = selectSchemaEntitiesMap(state, schema);
+  const relevantIDs = ids || Object.keys(schemaEntities);
+
+  return relevantIDs.map(entityId => schemaEntities[entityId]);
+}
+
+function selectSchemaEntitiesMap(
+  state: { entities: StateType },
+  schema: string
+): SchemaEntitiesMapType {
+  const schemaEntities = state.entities[schema];
+
+  if (!schemaEntities) {
+    throw new Error(
+      `Schema '${schema}' is unkown. Schemas in state are: [${Object.keys(
+        state.entities
+      ).join(", ")}]`
+    );
+  }
+
+  return schemaEntities;
+}

--- a/test/specs/selectors.spec.js
+++ b/test/specs/selectors.spec.js
@@ -1,0 +1,90 @@
+// @flow
+
+import { selectEntity, selectEntities } from "../../src/selectors";
+
+describe("selectors", () => {
+  function getTestState() {
+    return {
+      entities: {
+        articles: {
+          article_1: {
+            id: "article_1",
+            title: "Foo Bar 1"
+          },
+          article_2: {
+            id: "article_2",
+            title: "Foo Bar 2"
+          },
+          article_3: {
+            id: "article_3",
+            title: "Foo Bar 3"
+          }
+        }
+      }
+    };
+  }
+  describe("selectEntity", () => {
+    describe("when called with non-existent schema", () => {
+      test("throws an error", () => {
+        expect(() =>
+          selectEntity(getTestState(), "unkownSchema", "irrelevant_id")
+        ).toThrow(
+          "Schema 'unkownSchema' is unkown. Schemas in state are: [articles]"
+        );
+      });
+    });
+
+    describe("when called with existent id", () => {
+      test("returns the entity data", () => {
+        expect(selectEntity(getTestState(), "articles", "article_1")).toEqual({
+          id: "article_1",
+          title: "Foo Bar 1"
+        });
+      });
+    });
+
+    describe("when called with non-existent id", () => {
+      test("returns null", () => {
+        expect(
+          selectEntity(getTestState(), "articles", "article_non_existent")
+        ).toEqual(null);
+      });
+    });
+  });
+  describe("selectEntities", () => {
+    describe("when called with only the schema", () => {
+      test("returns array of all entities' data", () => {
+        expect(selectEntities(getTestState(), "articles")).toEqual([
+          {
+            id: "article_1",
+            title: "Foo Bar 1"
+          },
+          {
+            id: "article_2",
+            title: "Foo Bar 2"
+          },
+          {
+            id: "article_3",
+            title: "Foo Bar 3"
+          }
+        ]);
+      });
+    });
+    describe("when called with the schema and an array of IDs", () => {
+      test("returns array of the selected entities' data", () => {
+        expect(
+          selectEntities(getTestState(), "articles", ["article_2", "article_3"])
+        ).toEqual([
+          {
+            id: "article_2",
+            title: "Foo Bar 2"
+          },
+          {
+            id: "article_3",
+            title: "Foo Bar 3"
+          }
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- skipped an implementation based on `reselect` for now (this might change
  when we gain experience how typical memoized selectors can look like)